### PR TITLE
Arms - Single Target Update(s) [AOE rotation unchanged]

### DIFF
--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -26,30 +26,33 @@ function debugPrint(message, data)
 end
 
 local AR = {
-	Charge            = 100,
-	SweepingStrikes   = 260708,
-	Bladestorm        = 227847,
-	Ravager           = 152277,
-	Massacre          = 281001,
-	DeadlyCalm        = 262228,
-	Rend              = 772,
-	Skullsplitter     = 260643,
+	AncientAftershock = 325886,
 	Avatar            = 107574,
+	BloodFury         = 20572,
+	Bladestorm        = 227847,
+	Charge            = 100,
+	Cleave            = 845,
 	ColossusSmash     = 167105,
 	ColossusSmashAura = 208086,
-	Cleave            = 845,
-	DeepWoundsAura    = 262115,
-	Warbreaker        = 262161,
+	ConquerorsBanner  = 324143,
 	Condemn           = 330334,
+	DeadlyCalm        = 262228,
+	DeepWoundsAura    = 262115,
+	Dreadnaught       = 262150,
+	FervorOfBattle    = 202316,
+	Massacre          = 281001,
+	MortalStrike      = 12294,
+	Overpower         = 7384,
+	Ravager           = 152277,
+	Rend              = 772,
+	Skullsplitter     = 260643,
+	Slam              = 1464,
+	SpearOfBastion    = 307865,
 	SuddenDeath       = 29725,
 	SuddenDeathAura   = 52437,
-	Overpower         = 7384,
-	MortalStrike      = 12294,
-	Dreadnaught       = 262150,
+	SweepingStrikes   = 260708,
+	Warbreaker        = 262161,
 	Whirlwind         = 1680,
-	FervorOfBattle    = 202316,
-	Slam              = 1464,
-	BloodFury         = 20572,
 };
 
 setmetatable(AR, Warrior.spellMeta);
@@ -86,6 +89,19 @@ function Warrior:SingleTarget()
 
 	debugPrint(" ")
 	debugPrint("--- Running single target arms rotation ---");
+
+	-- Priority #-1: Casting Conqueror's Banner if you're a necrolord
+	if covenantId == Necrolord then
+		if cooldown[AR.ConquerorsBanner].ready then
+			debugPrint("* CHOOSING PRIORITY #-1 (CONQUERORS BANNER)")
+			MaxDps:GlowCooldown(
+				AR.ConquerorsBanner,
+				cooldown[AR.ConquerorsBanner].ready
+			);
+		else
+			debugPrint("SKIPPING PRIORITY #-1 (CONQUERORS BANNER)")
+		end
+	end
 
 	-- Priority #0: Casting avatar (if talented) in conjunction with colossus smash debuff
 	if talents[AR.Avatar] == 1 and
@@ -158,6 +174,18 @@ function Warrior:SingleTarget()
 		debugPrint("SKIPPING PRIORITY #2 (MORTAL STRIKE FOR DEEP WOUNDS REFRESH)")
 	end
 
+	-- Priority #2a: Deadly Calm if it's up
+	if talents[AR.DeadlyCalm] then
+		if spellChosen == false and cooldown[AR.DeadlyCalm].ready then
+			-- debugPrint("Deadly Calm ready?", cooldown[AR.DeadlyCalm].ready)
+			debugPrint("* CHOOSING PRIORITY #2a (DEADLY CALM)")
+			spellChosen = true
+			chosenSpell = AR.DeadlyCalm
+		else
+			debugPrint("SKIPPING PRIORITY #2a (DEADLY CALM)")
+		end
+	end
+
 	-- Priority #3: Overpower
 	if spellChosen == false and cooldown[AR.Overpower].ready then
 		-- debugPrint("Overpower ready?", cooldown[AR.Overpower].ready)
@@ -183,6 +211,28 @@ function Warrior:SingleTarget()
 		end
 	else
 		debugPrint("SKIPPING PRIORITY #4 (CONDEMN/EXECUTE)")
+	end
+
+	-- Priority #4a: Casting Spear of Bastion if you're a kyrian
+	if covenantId == Kyrian then
+		if cooldown[AR.SpearOfBastion].ready then
+			debugPrint("* CHOOSING PRIORITY #4a (SPEAR OF BASTION)")
+			chosenSpell = AR.SpearOfBastion
+			spellChosen = true
+		else
+			debugPrint("SKIPPING PRIORITY #4a (SPEAR OF BASTION)")
+		end
+	end
+
+	-- Priority #4b: Casting Ancient Aftershock if you're a night fae
+	if covenantId == NightFae then
+		if cooldown[AR.AncientAftershock].ready then
+			debugPrint("* CHOOSING PRIORITY #4b (ANCIENT AFTERSHOCK)")
+			chosenSpell = AR.AncientAftershock
+			spellChosen = true
+		else
+			debugPrint("SKIPPING PRIORITY #4b (ANCIENT AFTERSHOCK)")
+		end
 	end
 
 	-- Priority #5: Mortal Strike Generic

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -121,6 +121,16 @@ function Warrior:SingleTarget()
 		debugPrint("SKIPPING PRIORITY #0 (AVATAR)")
 	end
 
+	-- Priority 0a: Casting Ravager (if talented)
+	if talents[AR.Ravager] == 1 and
+		cooldown[AR.Ravager].ready then
+			chosenSpell = AR.Ravager
+			spellChosen = true
+		debugPrint("* CHOOSING PRIORITY #0a (RAVAGAR)")
+	else
+		debugPrint("SKIPPING PRIORITY #0a (RAVAGAR)")
+	end
+
 	-- Priority #1: Casting colossus smash or warbreaker (if talented)
 	if colossusSmashReadyNow then
 		-- debugPrint("Colossus smash and/or warbreaker ready now?", colossusSmashReadyNow)

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -13,6 +13,17 @@ local Necrolord = Enum.CovenantType.Necrolord;
 local Venthyr = Enum.CovenantType.Venthyr;
 local NightFae = Enum.CovenantType.NightFae;
 local Kyrian = Enum.CovenantType.Kyrian;
+local debug = true
+
+function debugPrint(message, data)
+	if (debug) then
+		if data ~= nil then
+			print(message, data)
+		else
+			print(message)
+		end
+	end
+end
 
 local AR = {
 	Charge            = 100,
@@ -31,6 +42,7 @@ local AR = {
 	Warbreaker        = 262161,
 	Condemn           = 330334,
 	SuddenDeath       = 29725,
+	SuddenDeathAura   = 52437,
 	Overpower         = 7384,
 	MortalStrike      = 12294,
 	Dreadnaught       = 262150,
@@ -42,51 +54,244 @@ local AR = {
 
 setmetatable(AR, Warrior.spellMeta);
 
-function Warrior:Arms()
+function Warrior:SingleTarget()
 	local fd = MaxDps.FrameData;
 	local cooldown = fd.cooldown;
 	local talents = fd.talents;
-	local targets = MaxDps:SmartAoe();
+	local debuff = fd.debuff;
+	local spellChosen = false
+	local chosenSpell = nil
+	local secondsRemainingOnDeepWoundsForRefreshPriority = 4
+	local secondsRemainingOnRendForRefreshPriority = 4
+	local colossusSmashReadyInTheNextEightSeconds = false
+	local colossusSmashReadyNow = false
+	local deepWoundsNeedsRefresh = false
+	local rendNeedsRefresh = false
+
+	if talents[AR.Warbreaker] then
+		colossusSmashReadyNow = cooldown[AR.Warbreaker].remains == 0
+		colossusSmashReadyInTheNextEightSeconds = cooldown[AR.Warbreaker].remains < 8
+	else
+		colossusSmashReadyNow = cooldown[AR.ColossusSmash].remains == 0
+		colossusSmashReadyInTheNextEightSeconds = cooldown[AR.ColossusSmash].remains < 8
+	end
+	
+	if debuff[AR.DeepWoundsAura].remains < secondsRemainingOnDeepWoundsForRefreshPriority then
+		deepWoundsNeedsRefresh = true
+	end
+
+	if talents[AR.Rend] and debuff[AR.Rend].remains < secondsRemainingOnRendForRefreshPriority then
+		rendNeedsRefresh = true
+	end
+
+	debugPrint(" ")
+	debugPrint("--- Running single target arms rotation ---");
+
+	-- Priority #0: Casting avatar (if talented) in conjunction with colossus smash debuff
+	if talents[AR.Avatar] == 1 and
+	   cooldown[AR.Avatar].ready and
+	   colossusSmashReadyInTheNextEightSeconds then
+		MaxDps:GlowCooldown(
+			AR.Avatar,
+			cooldown[AR.Avatar].ready and
+			colossusSmashReadyInTheNextEightSeconds
+		);
+
+		-- debugPrint("Avatar talented?", talents[AR.Avatar] == 1)
+		-- debugPrint("Avatar ready?", cooldown[AR.Avatar].ready)
+		-- debugPrint("Colossus smash has <8 seconds left on its cooldown?", colossusSmashReadyInTheNextEightSeconds)
+		debugPrint("* CHOOSING PRIORITY #0 (AVATAR)")
+	else
+		debugPrint("SKIPPING PRIORITY #0 (AVATAR)")
+	end
+
+	-- Priority #1: Casting colossus smash or warbreaker (if talented)
+	if colossusSmashReadyNow then
+		-- debugPrint("Colossus smash and/or warbreaker ready now?", colossusSmashReadyNow)
+		debugPrint("* CHOOSING PRIORITY #1 (WARBREAKER/COLOSSUS SMASH)")
+		spellChosen = true
+		if talents[AR.Warbreaker] then
+			chosenSpell = AR.Warbreaker
+		else
+			chosenSpell = AR.ColossusSmash
+		end
+	else
+		debugPrint("SKIPPING PRIORITY #1 (WARBREAKER/COLOSSUS SMASH)")
+	end
+
+	-- Priority #1a (optional depends on if talented): Rend refresh
+	if talents[AR.Rend] then
+		if spellChosen == false and rendNeedsRefresh then
+			-- debugPrint("talents[AR.Rend]", talents[AR.Rend])
+			-- debugPrint("rendNeedsRefresh", rendNeedsRefresh)
+			debugPrint("* CHOOSING PRIORITY #1a (REND REFRESH)")
+			spellChosen = true
+			chosenSpell = AR.Rend
+		else
+			debugPrint("SKIPPING PRIORITY #1a (REND REFRESH)")
+		end
+	end
+
+	-- Priority #1b (optional depends on if talented): cast Skullsplitter when <60 rage, and bladestorm isn't gonna be used soon
+	if talents[AR.Skullsplitter] then
+		if spellChosen == false and cooldown[AR.Skullsplitter].ready and fd.rage < 60 and cooldown[AR.Bladestorm].ready == false then
+			-- debugPrint("talents[AR.Warbreaker]", talents[AR.Warbreaker])
+			-- debugPrint("cooldown[AR.Skullsplitter].ready", cooldown[AR.Skullsplitter].ready)
+			-- debugPrint("rage < 60", fd.rage < 60)
+			-- debugPrint("cooldown[AR.Bladestorm].ready == false", cooldown[AR.Bladestorm].ready == false)
+			debugPrint("* CHOOSING PRIORITY #1b (skullsplitter if talented, and low rage and not using bladestorm soon)")
+			spellChosen = true
+			chosenSpell = AR.Skullsplitter
+		else
+			debugPrint("SKIPPING PRIORITY #1b (skullsplitter if talented, and low rage and not using bladestorm soon)")
+		end
+	end
+
+	-- Priority #2: Mortal Strike for Deep Wounds Refresh
+	if spellChosen == false and deepWoundsNeedsRefresh and cooldown[AR.MortalStrike].ready then
+		-- debugPrint("Deep wounds needs refresh?", deepWoundsNeedsRefresh)
+		-- debugPrint("Mortal strike ready?", cooldown[AR.MortalStrike].ready)
+		debugPrint("* CHOOSING PRIORITY #2 (MORTAL STRIKE FOR DEEP WOUNDS REFRESH)")
+		spellChosen = true
+		chosenSpell = AR.MortalStrike
+	else
+		debugPrint("SKIPPING PRIORITY #2 (MORTAL STRIKE FOR DEEP WOUNDS REFRESH)")
+	end
+
+	-- Priority #3: Overpower
+	if spellChosen == false and cooldown[AR.Overpower].ready then
+		-- debugPrint("Overpower ready?", cooldown[AR.Overpower].ready)
+		debugPrint("* CHOOSING PRIORITY #3 (OVERPOWER)")
+		spellChosen = true
+		chosenSpell = AR.Overpower
+	else
+		debugPrint("SKIPPING PRIORITY #3 (OVERPOWER)")
+	end
+
+	-- Priority #4: Execute/Condemn
+	if spellChosen == false and fd.canExecute then
+		-- debugPrint("Can execute/condemn?", fd.canExecute)
+		-- debugPrint("Venthyr", Venthyr)
+		-- debugPrint("covenentId", fd.covenantId)
+		-- debugPrint("Is player venthyr?", fd.covenantId == Venthyr)
+		debugPrint("* CHOOSING PRIORITY #4 (CONDEMN/EXECUTE)")
+		spellChosen = true
+		if fd.covenantId == Venthyr then
+			chosenSpell = AR.Condemn
+		else
+			chosenSpell = AR.Execute
+		end
+	else
+		debugPrint("SKIPPING PRIORITY #4 (CONDEMN/EXECUTE)")
+	end
+
+	-- Priority #5: Mortal Strike Generic
+	if spellChosen == false and cooldown[AR.MortalStrike].ready and fd.rage > 30 then
+		-- debugPrint("Mortal strike ready?", cooldown[AR.MortalStrike].ready)
+		debugPrint("* CHOOSING PRIORITY #5 (MORTAL STRIKE GENERIC)")
+		spellChosen = true
+		chosenSpell = AR.MortalStrike
+	else
+		debugPrint("SKIPPING PRIORITY #5 (MORTAL STRIKE GENERIC)")
+	end
+
+	-- Priority #6: Bladestorm during colossus smash
+	if spellChosen == false and debuff[AR.ColossusSmashAura].remains > 5 and cooldown[AR.Bladestorm].ready then
+		-- debugPrint("debuff[AR.ColossusSmashAura].remains", debuff[AR.ColossusSmashAura].remains)
+		-- debugPrint("cooldown[AR.Bladestorm].ready", cooldown[AR.Bladestorm].ready)
+		debugPrint("* CHOOSING PRIORITY #6 (BLADESTORM DURING COLOSSUS SMASH)")
+		spellChosen = true
+		chosenSpell = AR.Bladestorm
+	else
+		debugPrint("SKIPPING PRIORITY #6 (BLADESTORM DURING COLOSSUS SMASH)")
+	end
+
+
+	-- Priority #7: Slam Or Whirlwind (depending on fervor talent)
+	if spellChosen == false then
+		if talents[AR.FervorOfBattle] then
+			if fd.rage > 30 then
+				debugPrint("* CHOOSING PRIORITY #7 (WHIRLWIND)")
+				spellChosen = true
+				chosenSpell = AR.Whirlwind
+			else 
+				debugPrint("SKIPPING PRIORITY #7 (WHIRLWIND)")
+			end
+		else
+			if fd.rage > 20 then
+				debugPrint("* CHOOSING PRIORITY #7 (SLAM)")
+				spellChosen = true
+				chosenSpell = AR.Slam
+			else
+				debugPrint("SKIPPING PRIORITY #7 (SLAM)")
+			end
+		end
+	end
+
+	if chosenSpell then
+		return chosenSpell
+	else
+		debugPrint(" -- NO ACTIONS DETERMINED THIS FRAME -- LITERALLY STAND THERE AND AUTO ATTACK --")
+	end
+end
+
+function Warrior:TwoOrThreeTargets()
+end
+
+function Warrior:FourOrMoreTargets()
+end
+
+function Warrior:Arms()
+	local fd = MaxDps.FrameData;
+	local talents = fd.talents;
+	local targets = 1 --MaxDps:SmartAoe();
 	local targetHp = MaxDps:TargetPercentHealth() * 100;
 	local covenantId = fd.covenant.covenantId;
 	local rage = UnitPower('player', PowerTypeRage);
-	local canExecute = (talents[AR.Massacre] and targetHp < 35) or
-		targetHp < 20 or
-		(targetHp > 80 and covenantId == Venthyr);
+	local canExecute = talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up --false
+					   --rage > 20 and                                                  -- player has enough rage to execute, and any of the below conditions are met...
+					   --(targetHp < 20 or                                              -- target is <20% hp
+	                   --(talents[AR.Massacre] and targetHp < 35) or                    -- massacre is talented, and the target is <35% hp
+		               --(targetHp > 80 and covenantId == Venthyr) or                   -- player is venthyr, and target is >80% hp
+		               --(talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up));    -- sudden death is talented, and the sudden death aura is active on the player
+
 
 	fd.rage = rage;
 	fd.targetHp = targetHp;
 	fd.targets = targets;
+	fd.covenantId = covenantId;
 	fd.canExecute = canExecute;
 
-	if talents[AR.Avatar] then
-		-- avatar,if=cooldown.colossus_smash.remains<8&gcd.remains=0;
-		MaxDps:GlowCooldown(
-			AR.Avatar,
-			cooldown[AR.Avatar].ready and cooldown[AR.ColossusSmash].remains < 8
-		);
+	if targets >= 4 then
+		return Warrior:FourOrMoreTargets();
 	end
 
-	-- sweeping_strikes,if=spell_targets.whirlwind>1&(cooldown.bladestorm.remains>15|talent.ravager.enabled);
-	if cooldown[AR.SweepingStrikes].ready and
-		targets > 1 and
-		(cooldown[AR.Bladestorm].remains > 15 or talents[AR.Ravager])
-	then
-		return AR.SweepingStrikes;
+	if (targets >= 2) then
+		return Warrior:TwoOrThreeTargets();
 	end
 
-	-- run_action_list,name=hac,if=raid_event.adds.exists;
-	if targets > 1 then
-		return Warrior:ArmsHac();
-	end
+	return Warrior:SingleTarget();
 
-	-- run_action_list,name=execute,if=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20|(target.health.pct>80&covenant.venthyr);
-	if canExecute then
-		return Warrior:ArmsExecute();
-	end
+	-- -- sweeping_strikes,if=spell_targets.whirlwind>1&(cooldown.bladestorm.remains>15|talent.ravager.enabled);
+	-- if cooldown[AR.SweepingStrikes].ready and
+	-- 	targets > 1 and
+	-- 	(cooldown[AR.Bladestorm].remains > 15 or talents[AR.Ravager])
+	-- then
+	-- 	return AR.SweepingStrikes;
+	-- end
 
-	-- run_action_list,name=single_target;
-	return Warrior:ArmsSingleTarget();
+	-- -- run_action_list,name=hac,if=raid_event.adds.exists;
+	-- if targets > 1 then
+	-- 	return Warrior:ArmsHac();
+	-- end
+
+	-- -- run_action_list,name=execute,if=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20|(target.health.pct>80&covenant.venthyr);
+	-- if canExecute then
+	-- 	return Warrior:ArmsExecute();
+	-- end
+
+	-- -- run_action_list,name=single_target;
+	-- return Warrior:ArmsSingleTarget();
 end
 
 function Warrior:ArmsExecute()
@@ -160,8 +365,7 @@ function Warrior:ArmsExecute()
 	if covenantId == Venthyr and
 		rage >= 20 and
 		canExecute and
-		cooldown[AR.Condemn].ready and
-		(debuff[AR.ColossusSmashAura].up or buff[AR.SuddenDeath].up or rage > 65)
+		cooldown[AR.Condemn].ready
 	then
 		return AR.Condemn;
 	end

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -13,7 +13,7 @@ local Necrolord = Enum.CovenantType.Necrolord;
 local Venthyr = Enum.CovenantType.Venthyr;
 local NightFae = Enum.CovenantType.NightFae;
 local Kyrian = Enum.CovenantType.Kyrian;
-local debug = true
+local debug = false
 
 function debugPrint(message, data)
 	if (debug) then
@@ -112,10 +112,6 @@ function Warrior:SingleTarget()
 			cooldown[AR.Avatar].ready and
 			colossusSmashReadyInTheNextEightSeconds
 		);
-
-		-- debugPrint("Avatar talented?", talents[AR.Avatar] == 1)
-		-- debugPrint("Avatar ready?", cooldown[AR.Avatar].ready)
-		-- debugPrint("Colossus smash has <8 seconds left on its cooldown?", colossusSmashReadyInTheNextEightSeconds)
 		debugPrint("* CHOOSING PRIORITY #0 (AVATAR)")
 	else
 		debugPrint("SKIPPING PRIORITY #0 (AVATAR)")
@@ -134,7 +130,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #1: Casting colossus smash or warbreaker (if talented)
 	if colossusSmashReadyNow and spellChosen == false then
-		-- debugPrint("Colossus smash and/or warbreaker ready now?", colossusSmashReadyNow)
 		debugPrint("* CHOOSING PRIORITY #1 (WARBREAKER/COLOSSUS SMASH)")
 		spellChosen = true
 		if talents[AR.Warbreaker] then
@@ -149,8 +144,6 @@ function Warrior:SingleTarget()
 	-- Priority #1a (optional depends on if talented): Rend refresh
 	if talents[AR.Rend] then
 		if spellChosen == false and rendNeedsRefresh and fd.executePhase == false then
-			-- debugPrint("talents[AR.Rend]", talents[AR.Rend])
-			-- debugPrint("rendNeedsRefresh", rendNeedsRefresh)
 			debugPrint("* CHOOSING PRIORITY #1a (REND REFRESH)")
 			spellChosen = true
 			chosenSpell = AR.Rend
@@ -162,10 +155,6 @@ function Warrior:SingleTarget()
 	-- Priority #1b (optional depends on if talented): cast Skullsplitter when <60 rage, and bladestorm isn't gonna be used soon
 	if talents[AR.Skullsplitter] then
 		if spellChosen == false and cooldown[AR.Skullsplitter].ready and fd.rage < 60 and cooldown[AR.Bladestorm].ready == false then
-			-- debugPrint("talents[AR.Warbreaker]", talents[AR.Warbreaker])
-			-- debugPrint("cooldown[AR.Skullsplitter].ready", cooldown[AR.Skullsplitter].ready)
-			-- debugPrint("rage < 60", fd.rage < 60)
-			-- debugPrint("cooldown[AR.Bladestorm].ready == false", cooldown[AR.Bladestorm].ready == false)
 			debugPrint("* CHOOSING PRIORITY #1b (skullsplitter if talented, and low rage and not using bladestorm soon)")
 			spellChosen = true
 			chosenSpell = AR.Skullsplitter
@@ -176,8 +165,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #2: Mortal Strike for Deep Wounds Refresh
 	if spellChosen == false and deepWoundsNeedsRefresh and cooldown[AR.MortalStrike].ready then
-		-- debugPrint("Deep wounds needs refresh?", deepWoundsNeedsRefresh)
-		-- debugPrint("Mortal strike ready?", cooldown[AR.MortalStrike].ready)
 		debugPrint("* CHOOSING PRIORITY #2 (MORTAL STRIKE FOR DEEP WOUNDS REFRESH)")
 		spellChosen = true
 		chosenSpell = AR.MortalStrike
@@ -188,7 +175,6 @@ function Warrior:SingleTarget()
 	-- Priority #2a: Deadly Calm if it's up
 	if talents[AR.DeadlyCalm] then
 		if spellChosen == false and cooldown[AR.DeadlyCalm].ready then
-			-- debugPrint("Deadly Calm ready?", cooldown[AR.DeadlyCalm].ready)
 			debugPrint("* CHOOSING PRIORITY #2a (DEADLY CALM)")
 			spellChosen = true
 			chosenSpell = AR.DeadlyCalm
@@ -199,7 +185,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #3: Overpower
 	if spellChosen == false and cooldown[AR.Overpower].ready then
-		-- debugPrint("Overpower ready?", cooldown[AR.Overpower].ready)
 		debugPrint("* CHOOSING PRIORITY #3 (OVERPOWER)")
 		spellChosen = true
 		chosenSpell = AR.Overpower
@@ -209,10 +194,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #4: Execute/Condemn
 	if spellChosen == false and fd.canExecute then
-		-- debugPrint("Can execute/condemn?", fd.canExecute)
-		-- debugPrint("Venthyr", Venthyr)
-		-- debugPrint("covenentId", fd.covenantId)
-		-- debugPrint("Is player venthyr?", fd.covenantId == Venthyr)
 		debugPrint("* CHOOSING PRIORITY #4 (CONDEMN/EXECUTE)")
 		spellChosen = true
 		if fd.covenantId == Venthyr then
@@ -248,7 +229,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #5: Mortal Strike Generic
 	if spellChosen == false and cooldown[AR.MortalStrike].ready and fd.rage > 30 and fd.executePhase == false then
-		-- debugPrint("Mortal strike ready?", cooldown[AR.MortalStrike].ready)
 		debugPrint("* CHOOSING PRIORITY #5 (MORTAL STRIKE GENERIC)")
 		spellChosen = true
 		chosenSpell = AR.MortalStrike
@@ -258,8 +238,6 @@ function Warrior:SingleTarget()
 
 	-- Priority #6: Bladestorm during colossus smash
 	if spellChosen == false and debuff[AR.ColossusSmashAura].remains > 5 and cooldown[AR.Bladestorm].ready then
-		-- debugPrint("debuff[AR.ColossusSmashAura].remains", debuff[AR.ColossusSmashAura].remains)
-		-- debugPrint("cooldown[AR.Bladestorm].ready", cooldown[AR.Bladestorm].ready)
 		debugPrint("* CHOOSING PRIORITY #6 (BLADESTORM DURING COLOSSUS SMASH)")
 		spellChosen = true
 		chosenSpell = AR.Bladestorm

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -413,7 +413,7 @@ end
 function Warrior:Arms()
 	local fd = MaxDps.FrameData;
 	local talents = fd.talents;
-	local targets = 1 --MaxDps:SmartAoe();
+	local targets = MaxDps:SmartAoe();
 	local targetHp = MaxDps:TargetPercentHealth() * 100;
 	local covenantId = fd.covenant.covenantId;
 	local rage = UnitPower('player', PowerTypeRage);

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -270,7 +270,7 @@ function Warrior:SingleTarget()
 
 	-- Priority #7: Slam Or Whirlwind (depending on fervor talent)
 	if talents[AR.FervorOfBattle] then
-		if spellChosen == false and fd.rage > 30 fd.executePhase == false then
+		if spellChosen == false and fd.rage > 30 and fd.executePhase == false then
 			debugPrint("* CHOOSING PRIORITY #7 (WHIRLWIND)")
 			spellChosen = true
 			chosenSpell = AR.Whirlwind

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -148,7 +148,7 @@ function Warrior:SingleTarget()
 
 	-- Priority #1a (optional depends on if talented): Rend refresh
 	if talents[AR.Rend] then
-		if spellChosen == false and rendNeedsRefresh then
+		if spellChosen == false and rendNeedsRefresh and fd.executePhase == false then
 			-- debugPrint("talents[AR.Rend]", talents[AR.Rend])
 			-- debugPrint("rendNeedsRefresh", rendNeedsRefresh)
 			debugPrint("* CHOOSING PRIORITY #1a (REND REFRESH)")
@@ -225,7 +225,7 @@ function Warrior:SingleTarget()
 	end
 
 	-- Priority #4a: Casting Spear of Bastion if you're a kyrian
-	if covenantId == Kyrian then
+	if covenantId == Kyrian and fd.executePhase == false then
 		if cooldown[AR.SpearOfBastion].ready then
 			debugPrint("* CHOOSING PRIORITY #4a (SPEAR OF BASTION)")
 			chosenSpell = AR.SpearOfBastion
@@ -236,7 +236,7 @@ function Warrior:SingleTarget()
 	end
 
 	-- Priority #4b: Casting Ancient Aftershock if you're a night fae
-	if covenantId == NightFae then
+	if covenantId == NightFae and fd.executePhase == false then
 		if cooldown[AR.AncientAftershock].ready then
 			debugPrint("* CHOOSING PRIORITY #4b (ANCIENT AFTERSHOCK)")
 			chosenSpell = AR.AncientAftershock
@@ -247,7 +247,7 @@ function Warrior:SingleTarget()
 	end
 
 	-- Priority #5: Mortal Strike Generic
-	if spellChosen == false and cooldown[AR.MortalStrike].ready and fd.rage > 30 then
+	if spellChosen == false and cooldown[AR.MortalStrike].ready and fd.rage > 30 and fd.executePhase == false then
 		-- debugPrint("Mortal strike ready?", cooldown[AR.MortalStrike].ready)
 		debugPrint("* CHOOSING PRIORITY #5 (MORTAL STRIKE GENERIC)")
 		spellChosen = true
@@ -270,7 +270,7 @@ function Warrior:SingleTarget()
 
 	-- Priority #7: Slam Or Whirlwind (depending on fervor talent)
 	if talents[AR.FervorOfBattle] then
-		if spellChosen == false and fd.rage > 30 then
+		if spellChosen == false and fd.rage > 30 fd.executePhase == false then
 			debugPrint("* CHOOSING PRIORITY #7 (WHIRLWIND)")
 			spellChosen = true
 			chosenSpell = AR.Whirlwind
@@ -278,7 +278,7 @@ function Warrior:SingleTarget()
 			debugPrint("SKIPPING PRIORITY #7 (WHIRLWIND)")
 		end
 	else
-		if spellChosen == false and fd.rage > 20 then
+		if spellChosen == false and fd.rage > 20 and fd.executePhase == false then
 			debugPrint("* CHOOSING PRIORITY #7 (SLAM)")
 			spellChosen = true
 			chosenSpell = AR.Slam
@@ -309,18 +309,19 @@ function Warrior:Arms()
 	local targetHp = MaxDps:TargetPercentHealth() * 100;
 	local covenantId = fd.covenant.covenantId;
 	local rage = UnitPower('player', PowerTypeRage);
-	local canExecute = rage > 20 and                                                   -- player has enough rage to execute, and any of the below conditions are met...
-					   ((targetHp < 20) or                                             -- target is <20% hp
-	                    (talents[AR.Massacre] and targetHp < 35) or                    -- massacre is talented, and the target is <35% hp
-		                (targetHp > 80 and covenantId == Venthyr) or                   -- player is venthyr, and target is >80% hp
+	local executePhase = ((targetHp < 20) or                                           -- target is <20% hp
+						  (talents[AR.Massacre] and targetHp < 35) or                  -- massacre is talented, and the target is <35% hp
+						  (targetHp > 80 and covenantId == Venthyr))                   -- player is venthyr, and target is >80% hp
+	local canExecute = rage > 20 and                                                   -- player has enough rage to execute
+					   (executePhase or                                                -- its execute phase
 		                (talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up)); -- sudden death is talented, and the sudden death aura is active on the player
-
 
 	fd.rage = rage;
 	fd.targetHp = targetHp;
 	fd.targets = targets;
 	fd.covenantId = covenantId;
 	fd.canExecute = canExecute;
+	fd.executePhase = executePhase
 
 	if targets >= 4 then
 		return Warrior:FourOrMoreTargets();

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -122,17 +122,18 @@ function Warrior:SingleTarget()
 	end
 
 	-- Priority 0a: Casting Ravager (if talented)
-	if talents[AR.Ravager] == 1 and
-		cooldown[AR.Ravager].ready then
-			chosenSpell = AR.Ravager
-			spellChosen = true
-		debugPrint("* CHOOSING PRIORITY #0a (RAVAGAR)")
-	else
-		debugPrint("SKIPPING PRIORITY #0a (RAVAGAR)")
+	if talents[AR.Ravager] == 1 then
+		if cooldown[AR.Ravager].ready then
+		   chosenSpell = AR.Ravager
+		   spellChosen = true
+			debugPrint("* CHOOSING PRIORITY #0a (RAVAGAR)")
+		else
+			debugPrint("SKIPPING PRIORITY #0a (RAVAGAR)")
+		end
 	end
 
 	-- Priority #1: Casting colossus smash or warbreaker (if talented)
-	if colossusSmashReadyNow then
+	if colossusSmashReadyNow and spellChosen == false then
 		-- debugPrint("Colossus smash and/or warbreaker ready now?", colossusSmashReadyNow)
 		debugPrint("* CHOOSING PRIORITY #1 (WARBREAKER/COLOSSUS SMASH)")
 		spellChosen = true

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -208,23 +208,21 @@ function Warrior:SingleTarget()
 
 
 	-- Priority #7: Slam Or Whirlwind (depending on fervor talent)
-	if spellChosen == false then
-		if talents[AR.FervorOfBattle] then
-			if fd.rage > 30 then
-				debugPrint("* CHOOSING PRIORITY #7 (WHIRLWIND)")
-				spellChosen = true
-				chosenSpell = AR.Whirlwind
-			else 
-				debugPrint("SKIPPING PRIORITY #7 (WHIRLWIND)")
-			end
+	if talents[AR.FervorOfBattle] then
+		if spellChosen == false and fd.rage > 30 then
+			debugPrint("* CHOOSING PRIORITY #7 (WHIRLWIND)")
+			spellChosen = true
+			chosenSpell = AR.Whirlwind
+		else 
+			debugPrint("SKIPPING PRIORITY #7 (WHIRLWIND)")
+		end
+	else
+		if spellChosen == false and fd.rage > 20 then
+			debugPrint("* CHOOSING PRIORITY #7 (SLAM)")
+			spellChosen = true
+			chosenSpell = AR.Slam
 		else
-			if fd.rage > 20 then
-				debugPrint("* CHOOSING PRIORITY #7 (SLAM)")
-				spellChosen = true
-				chosenSpell = AR.Slam
-			else
-				debugPrint("SKIPPING PRIORITY #7 (SLAM)")
-			end
+			debugPrint("SKIPPING PRIORITY #7 (SLAM)")
 		end
 	end
 

--- a/Specialization/Arms.lua
+++ b/Specialization/Arms.lua
@@ -234,9 +234,11 @@ function Warrior:SingleTarget()
 end
 
 function Warrior:TwoOrThreeTargets()
+	-- TODO
 end
 
 function Warrior:FourOrMoreTargets()
+	-- TODO
 end
 
 function Warrior:Arms()
@@ -246,12 +248,11 @@ function Warrior:Arms()
 	local targetHp = MaxDps:TargetPercentHealth() * 100;
 	local covenantId = fd.covenant.covenantId;
 	local rage = UnitPower('player', PowerTypeRage);
-	local canExecute = talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up --false
-					   --rage > 20 and                                                  -- player has enough rage to execute, and any of the below conditions are met...
-					   --(targetHp < 20 or                                              -- target is <20% hp
-	                   --(talents[AR.Massacre] and targetHp < 35) or                    -- massacre is talented, and the target is <35% hp
-		               --(targetHp > 80 and covenantId == Venthyr) or                   -- player is venthyr, and target is >80% hp
-		               --(talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up));    -- sudden death is talented, and the sudden death aura is active on the player
+	local canExecute = rage > 20 and                                                   -- player has enough rage to execute, and any of the below conditions are met...
+					   ((targetHp < 20) or                                             -- target is <20% hp
+	                    (talents[AR.Massacre] and targetHp < 35) or                    -- massacre is talented, and the target is <35% hp
+		                (targetHp > 80 and covenantId == Venthyr) or                   -- player is venthyr, and target is >80% hp
+		                (talents[AR.SuddenDeath] and fd.buff[AR.SuddenDeathAura].up)); -- sudden death is talented, and the sudden death aura is active on the player
 
 
 	fd.rage = rage;


### PR DESCRIPTION
Here are the new round of updates to **WARRIOR - ARMS**

1. added proper support for condemn
2. fixed errors in APL...
   - fixed missing handling of sudden death aura procs
   - fixed an issue where the APL wouldn't have you casting condemn unless colossus smash was up?!
   - fixed an issue where deep wounds refresh wasn't given appropriate priority
   - fixed missing Sudden Death aura ID (52437)
3. added support for 3 missing covenant spells
   - kyrian -> spear of bastion
   - necrolord -> conqueror's banner
   - night fae -> ancient aftershock
4. Sorted warrior spell table alphabetically 🤷 
5. Changed the structure a bit to primarily split based on # of targets (single target or multiple), and leave it up to those respective code paths to handle their execute/condemn usage

# DPS Test Results

**single target (non-execute), current code:** 2.3k - 2.2k - 2.5k - 2.5k - 2.2k - 2.5k - 2.5k

**single target (non-execute), new code**: 2.6k - 2.8k - 3.0k - 2.4k - 3.2k - 2.7k - 2.8k